### PR TITLE
Backport "fix avoid removing tag style on custom sanitize" to v0.22-stable

### DIFF
--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -22,6 +22,14 @@ module Decidim
       end
     end
 
+    def decidim_sanitize_newsletter(html, options = {})
+      if options[:strip_tags]
+        strip_tags sanitize(html, scrubber: Decidim::NewsletterScrubber.new)
+      else
+        sanitize(html, scrubber: Decidim::NewsletterScrubber.new)
+      end
+    end
+
     def decidim_html_escape(text)
       ERB::Util.unwrapped_html_escape(text.to_str)
     end

--- a/decidim-core/app/scrubbers/decidim/newsletter_scrubber.rb
+++ b/decidim-core/app/scrubbers/decidim/newsletter_scrubber.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Use this class as a scrubber to sanitize user input. The default
+  # scrubbed provided by Rails does not allow `iframe`s, and we're using
+  # them to embed videos, so we need to provide a whole new scrubber.
+  #
+  # Example:
+  #
+  #    sanitize(@page.body, scrubber: Decidim::UserInputScrubber.new)
+  #
+  # Lists of default tags and attributes are extracted from
+  # https://stackoverflow.com/a/35073814/2110884.
+  class NewsletterScrubber < Rails::Html::PermitScrubber
+    def initialize
+      super
+      self.tags = custom_allowed_tags
+      self.attributes = custom_allowed_attributes
+    end
+
+    private
+
+    def custom_allowed_attributes
+      Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES + %w(frameborder allowfullscreen) - %w(onerror)
+    end
+
+    def custom_allowed_tags
+      Loofah::HTML5::SafeList::ALLOWED_ELEMENTS_WITH_LIBXML2 + %w(iframe style)
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/newsletter_mailer/newsletter.html.erb
+++ b/decidim-core/app/views/decidim/newsletter_mailer/newsletter.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_sanitize cell.to_s %>
+<%= decidim_sanitize_newsletter cell.to_s %>
 
 <% content_for :note do %>
   <%== t ".note", organization_name: h(@organization.name), link: decidim.notifications_settings_url(host: @organization.host) %>

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -11,6 +11,8 @@ module Decidim
         it "strips the tags from the target string" do
           expect(helper.decidim_sanitize(user_input, strip_tags: true)).not_to include("<p>")
           expect(helper.decidim_sanitize(user_input, strip_tags: true)).not_to include("</p>")
+          expect(helper.decidim_sanitize_newsletter(user_input, strip_tags: true)).not_to include("<p>")
+          expect(helper.decidim_sanitize_newsletter(user_input, strip_tags: true)).not_to include("</p>")
         end
 
         context "when there is no tags in user_input" do
@@ -18,6 +20,7 @@ module Decidim
 
           it "does not strip the target string" do
             expect(helper.decidim_sanitize(user_input, strip_tags: true)).to eq(user_input)
+            expect(helper.decidim_sanitize_newsletter(user_input, strip_tags: true)).to eq(user_input)
           end
         end
 
@@ -26,6 +29,7 @@ module Decidim
 
           it "does not strip the target string" do
             expect(helper.decidim_sanitize(user_input, strip_tags: false)).to eq(user_input)
+            expect(helper.decidim_sanitize_newsletter(user_input, strip_tags: false)).to eq(user_input)
           end
         end
       end
@@ -35,6 +39,9 @@ module Decidim
           expect(helper.decidim_sanitize(user_input)).to include("<p>")
           expect(helper.decidim_sanitize(user_input)).to include("</p>")
           expect(helper.decidim_sanitize(user_input)).to eq(user_input)
+          expect(helper.decidim_sanitize_newsletter(user_input)).to include("<p>")
+          expect(helper.decidim_sanitize_newsletter(user_input)).to include("</p>")
+          expect(helper.decidim_sanitize_newsletter(user_input)).to eq(user_input)
         end
       end
     end

--- a/decidim-core/spec/scrubbers/decidim/newsletter_scrubber_spec.rb
+++ b/decidim-core/spec/scrubbers/decidim/newsletter_scrubber_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NewsletterScrubber do
+  subject { described_class.new }
+
+  def scrub(html)
+    Loofah.scrub_fragment(html, subject).to_s
+  end
+
+  RSpec::Matchers.define :be_scrubbed do
+    match do |actual|
+      expect(scrub(actual)).to eq actual
+    end
+
+    failure_message do |actual|
+      "expected \"#{actual}\" to eq \"#{scrub(actual)}\" after scrubbing"
+    end
+  end
+
+  RSpec::Matchers.define :be_scrubbed_as do |expected|
+    match do |actual|
+      expect(scrub(actual)).to eq expected
+    end
+
+    failure_message do |actual|
+      "expected \"#{actual}\" to eq \"#{expected}\" after scrubbing, scrubbed as \"#{scrub(actual)}\" instead"
+    end
+  end
+
+  it "allows iframes to embed videos" do
+    html = "<iframe frameborder=\"0\" allowfullscreen=\"true\" src=\"url\"></iframe>"
+    expect(html).to be_scrubbed
+  end
+
+  it "allows style tags" do
+    html = "<style> body{ color: red; } </style>"
+    expect(html).to be_scrubbed
+  end
+
+  it "allows most basic tags" do
+    html = "<a></a><b></b><strong></strong><em></em><i></i><p></p><br>"
+    expect(html).to be_scrubbed
+  end
+
+  it "does not allow scripts" do
+    html = "<script></script>"
+    expect(html).to be_scrubbed_as("")
+  end
+
+  it "does not allow onerror attributes" do
+    html = "<img src=x onerror=alert(1)>"
+    expect(html).to be_scrubbed_as("<img src=\"x\">")
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport to 0.22-stable release of avoid removing tag style on custom sanitizing

#### :pushpin: Related Issues
- Related to [decidim/7018](https://github.com/decidim/decidim/pull/7018)
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
