### PR TITLE
Backport "Fix space private user in process admin" to release/0.22-stable

### DIFF
--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -233,6 +233,7 @@ module Decidim
           :process,
           :process_step,
           :process_user_role,
+          :space_private_user,
           :export_space,
           :import
         ].include?(permission_action.subject)

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -396,6 +396,7 @@ describe Decidim::ParticipatoryProcesses::Permissions do
       it_behaves_like "allows any action on subject", :process
       it_behaves_like "allows any action on subject", :process_step
       it_behaves_like "allows any action on subject", :process_user_role
+      it_behaves_like "allows any action on subject", :space_private_user
     end
 
     context "when user is an org admin" do

--- a/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
@@ -42,7 +42,7 @@ describe "Invite process administrator", type: :system do
       end
 
       within ".secondary-nav" do
-        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nModerations"
+        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nPrivate participants\nModerations"
       end
     end
   end
@@ -72,7 +72,7 @@ describe "Invite process administrator", type: :system do
       end
 
       within ".secondary-nav" do
-        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nModerations"
+        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nPrivate participants\nModerations"
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport "Fix space private user in process admin" to release/0.22-stable

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/7067

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
